### PR TITLE
Work on MQTT_communicator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ if(BUILD_SHARED_LIBS)
 	message(FATAL_ERROR "BUILD_SHARED_LIBS=ON is not supported yet. Use static libs instead.")
 endif()
 
+set(ENABLE_LOGGING ON CACHE BOOL "Enable logging with boost.log.")
+if(ENABLE_LOGGING)
+	add_definitions(-DFASTLIB_ENABLE_LOGGING)
+endif()
+
 # Library names
 set(FASTLIB_COMMUNICATION "fastlib_communication")
 set(FASTLIB_SERIALIZATION "fastlib_serialization")

--- a/communication/CMakeLists.txt
+++ b/communication/CMakeLists.txt
@@ -23,15 +23,19 @@ include_directories(SYSTEM "${MOSQUITTO_INCLUDE_DIR}")
 add_library(${FASTLIB_COMMUNICATION} ${SRC})
 
 # Merge with dependent libraries
-add_dependencies(${FASTLIB_COMMUNICATION} ${BoostRegexLibs} ${BoostLogLibs})
+add_dependencies(${FASTLIB_COMMUNICATION} ${BoostRegexLibs})
 get_property(BOOST_REGEX_LIBRARY TARGET ${BoostRegexLibs} PROPERTY LOCATION)
-get_property(BOOST_LOG_LIBRARY TARGET ${BoostLogLibs} PROPERTY LOCATION)
-get_property(BOOST_CHRONO_LIBRARY TARGET ${BoostChronoLibs} PROPERTY LOCATION) # dependency of boost.log
-get_property(BOOST_DATE_TIME_LIBRARY TARGET ${BoostDateTimeLibs} PROPERTY LOCATION) # dependency of boost.log
-get_property(BOOST_FILESYSTEM_LIBRARY TARGET ${BoostFilesystemLibs} PROPERTY LOCATION) # dependency of boost.log
-get_property(BOOST_THREAD_LIBRARY TARGET ${BoostThreadLibs} PROPERTY LOCATION) # dependency of boost.log
-get_property(BOOST_SYSTEM_LIBRARY TARGET ${BoostSystemLibs} PROPERTY LOCATION) # dependency of boost.log
-set(LIBS ${MOSQUITTO_LIBRARIES} ${BOOST_REGEX_LIBRARY} ${BOOST_LOG_LIBRARY} ${BOOST_CHRONO_LIBRARY} ${BOOST_DATE_TIME_LIBRARY} ${BOOST_FILESYSTEM_LIBRARY} ${BOOST_THREAD_LIBRARY} ${BOOST_SYSTEM_LIBRARY})
+set(LIBS ${MOSQUITTO_LIBRARIES} ${BOOST_REGEX_LIBRARY})
+if(ENABLE_LOGGING)
+	add_dependencies(${FASTLIB_COMMUNICATION} ${BoostLogLibs})
+	get_property(BOOST_LOG_LIBRARY TARGET ${BoostLogLibs} PROPERTY LOCATION)
+	get_property(BOOST_CHRONO_LIBRARY TARGET ${BoostChronoLibs} PROPERTY LOCATION) # dependency of boost.log
+	get_property(BOOST_DATE_TIME_LIBRARY TARGET ${BoostDateTimeLibs} PROPERTY LOCATION) # dependency of boost.log
+	get_property(BOOST_FILESYSTEM_LIBRARY TARGET ${BoostFilesystemLibs} PROPERTY LOCATION) # dependency of boost.log
+	get_property(BOOST_THREAD_LIBRARY TARGET ${BoostThreadLibs} PROPERTY LOCATION) # dependency of boost.log
+	get_property(BOOST_SYSTEM_LIBRARY TARGET ${BoostSystemLibs} PROPERTY LOCATION) # dependency of boost.log
+	set(LIBS ${LIBS} ${BOOST_LOG_LIBRARY} ${BOOST_CHRONO_LIBRARY} ${BOOST_DATE_TIME_LIBRARY} ${BOOST_FILESYSTEM_LIBRARY} ${BOOST_THREAD_LIBRARY} ${BOOST_SYSTEM_LIBRARY})
+endif()
 MERGE_STATIC_LIBRARIES(${FASTLIB_COMMUNICATION} ALL "${LIBS}")
 # As librt should always be available it is linked dynamically and therefore has to be linked in applications
 # that use fast-lib as well.

--- a/communication/communicator.hpp
+++ b/communication/communicator.hpp
@@ -14,7 +14,7 @@
 namespace fast {
 
 /**
- * \brief An abstract class to provide an interface for communication.
+ * \brief An abstract class to provide an minimal interface for communication.
  *
  * This interface provides a method to send messages and to get incoming messages.
  */

--- a/communication/mqtt_communicator.cpp
+++ b/communication/mqtt_communicator.cpp
@@ -123,7 +123,7 @@ MQTT_communicator::MQTT_communicator(const std::string &id,
 				     int port,
 				     int keepalive,
 				     const timeout_duration_t &timeout) :
-	mosqpp::mosquittopp(id.c_str()),
+	mosqpp::mosquittopp(id == "" ? nullptr : id.c_str()),
 	default_publish_topic(publish_topic),
 	connected(false)
 {

--- a/communication/mqtt_communicator.hpp
+++ b/communication/mqtt_communicator.hpp
@@ -31,6 +31,8 @@ class MQTT_subscription;
 
 /**
  * \brief A specialized Communicator to provide communication using the MQTT framework mosquitto.
+ *
+ * This class is threadsafe.
  */
 class MQTT_communicator : 
 	public Communicator, 
@@ -39,6 +41,8 @@ class MQTT_communicator :
 public:
 	/**
 	 * \brief The type of the timeout duration.
+	 *
+	 * The type must provide a max() method, which is reserved for no timeout.
 	 */
 	using timeout_duration_t = std::chrono::duration<double>;
 
@@ -66,11 +70,9 @@ public:
 	 * \brief Constructor for MQTT_communicator.
 	 *
 	 * Establishes a connection, starts async mosquitto loop and subscribes to topic.
-	 * The async mosquitto loop runs in a seperate thread so internal functions should be threadsafe.
-	 * There is no need to initialize mosquitto before using this class, because this is handled in the constructor
-	 * and destructor.
-	 * Establishing a connection is retried every second until success or timeout.
-	 * This overload also adds an initial subscription to a topic.
+	 * If the connect attempt fails, it tries to reconnect every second until success or timeout.
+	 * To disable the timeout it has to be set to "timeout_duration_t::max()" (default).
+	 * This overload also adds an default subscription to a topic.
 	 * \param id The id of this client. Must be unique, so the broker can identify this client.
 	 * \param subscribe_topic The topic to subscribe to by default.
 	 * \param publish_topic The topic to publish messages to by default.

--- a/communication/mqtt_communicator.hpp
+++ b/communication/mqtt_communicator.hpp
@@ -52,7 +52,7 @@ public:
 	 * Establishes a connection and starts async mosquitto loop.
 	 * If the connect attempt fails, it tries to reconnect every second until success or timeout.
 	 * To disable the timeout it has to be set to "timeout_duration_t::max()" (default).
-	 * \param id The id of this client. Must be unique, so the broker can identify this client.
+	 * \param id The id of this client. Must be unique, so the broker can identify this client. An empty string ("") can be passed for a random id.
 	 * \param publish_topic The topic to publish messages to by default.
 	 * \param host The host to connect to.
 	 * \param port The port to connect to.
@@ -73,7 +73,7 @@ public:
 	 * If the connect attempt fails, it tries to reconnect every second until success or timeout.
 	 * To disable the timeout it has to be set to "timeout_duration_t::max()" (default).
 	 * This overload also adds an default subscription to a topic.
-	 * \param id The id of this client. Must be unique, so the broker can identify this client.
+	 * \param id The id of this client. Must be unique, so the broker can identify this client. An empty string ("") can be passed for a random id.
 	 * \param subscribe_topic The topic to subscribe to by default.
 	 * \param publish_topic The topic to publish messages to by default.
 	 * \param host The host to connect to.

--- a/examples/comm_serial/CMakeLists.txt
+++ b/examples/comm_serial/CMakeLists.txt
@@ -6,6 +6,8 @@
 # Version 3, 29 June 2007. For details see 'LICENSE.md' in the root directory.
 #
 
+set(FASTLIB_EXAMPLE_COMM_SERIAL "fastlib_example_comm_serial")
+
 ### Define source files.
 set(SRC ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
@@ -14,10 +16,24 @@ include_directories(${PROJECT_SOURCE_DIR})
 include_directories(SYSTEM "${MOSQUITTO_INCLUDE_DIR}")
 include_directories(SYSTEM "${YAMLCPP_INCLUDE_DIR}")
 
-
 ### Build and installation targets
 # Add executable
-add_executable(fastlib_example_comm_serial ${SRC})
-target_link_libraries(fastlib_example_comm_serial ${FASTLIB_COMMUNICATION} ${FASTLIB_SERIALIZATION})
-target_link_libraries(fastlib_example_comm_serial -lpthread)
-add_test(comm_serial_tests fastlib_example_comm_serial)
+add_executable(${FASTLIB_EXAMPLE_COMM_SERIAL} ${SRC})
+
+# Link libraries
+target_link_libraries(${FASTLIB_EXAMPLE_COMM_SERIAL} ${FASTLIB_COMMUNICATION} ${FASTLIB_SERIALIZATION})
+target_link_libraries(${FASTLIB_EXAMPLE_COMM_SERIAL} -lpthread)
+
+# Link boost.log
+add_dependencies(${FASTLIB_EXAMPLE_COMM_SERIAL} ${BoostLogLibs})
+get_property(BOOST_LOG_LIBRARY TARGET ${BoostLogLibs} PROPERTY LOCATION)
+get_property(BOOST_CHRONO_LIBRARY TARGET ${BoostChronoLibs} PROPERTY LOCATION) # dependency of boost.log
+get_property(BOOST_DATE_TIME_LIBRARY TARGET ${BoostDateTimeLibs} PROPERTY LOCATION) # dependency of boost.log
+get_property(BOOST_FILESYSTEM_LIBRARY TARGET ${BoostFilesystemLibs} PROPERTY LOCATION) # dependency of boost.log
+get_property(BOOST_THREAD_LIBRARY TARGET ${BoostThreadLibs} PROPERTY LOCATION) # dependency of boost.log
+get_property(BOOST_SYSTEM_LIBRARY TARGET ${BoostSystemLibs} PROPERTY LOCATION) # dependency of boost.log
+set(LIBS ${BOOST_LOG_LIBRARY} ${BOOST_CHRONO_LIBRARY} ${BOOST_DATE_TIME_LIBRARY} ${BOOST_FILESYSTEM_LIBRARY} ${BOOST_THREAD_LIBRARY} ${BOOST_SYSTEM_LIBRARY})
+target_link_libraries(${FASTLIB_EXAMPLE_COMM_SERIAL} ${LIBS})
+
+# Add test
+add_test(comm_serial_tests ${FASTLIB_EXAMPLE_COMM_SERIAL})

--- a/examples/communication/CMakeLists.txt
+++ b/examples/communication/CMakeLists.txt
@@ -6,6 +6,8 @@
 # Version 3, 29 June 2007. For details see 'LICENSE.md' in the root directory.
 #
 
+set(FASTLIB_EXAMPLE_COMMUNICATION "fastlib_example_communication")
+
 ### Define source files.
 set(SRC ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
@@ -15,7 +17,22 @@ include_directories(SYSTEM "${MOSQUITTO_INCLUDE_DIR}")
 
 ### Build and installation targets
 # Add executable
-add_executable(fastlib_example_communication ${SRC})
-target_link_libraries(fastlib_example_communication ${FASTLIB_COMMUNICATION})
-target_link_libraries(fastlib_example_communication -lpthread)
-add_test(communication_tests fastlib_example_communication)
+add_executable(${FASTLIB_EXAMPLE_COMMUNICATION} ${SRC})
+
+# Link libraries
+target_link_libraries(${FASTLIB_EXAMPLE_COMMUNICATION} ${FASTLIB_COMMUNICATION})
+target_link_libraries(${FASTLIB_EXAMPLE_COMMUNICATION} -lpthread)
+
+# Link boost.log
+add_dependencies(${FASTLIB_EXAMPLE_COMMUNICATION} ${BoostLogLibs})
+get_property(BOOST_LOG_LIBRARY TARGET ${BoostLogLibs} PROPERTY LOCATION)
+get_property(BOOST_CHRONO_LIBRARY TARGET ${BoostChronoLibs} PROPERTY LOCATION) # dependency of boost.log
+get_property(BOOST_DATE_TIME_LIBRARY TARGET ${BoostDateTimeLibs} PROPERTY LOCATION) # dependency of boost.log
+get_property(BOOST_FILESYSTEM_LIBRARY TARGET ${BoostFilesystemLibs} PROPERTY LOCATION) # dependency of boost.log
+get_property(BOOST_THREAD_LIBRARY TARGET ${BoostThreadLibs} PROPERTY LOCATION) # dependency of boost.log
+get_property(BOOST_SYSTEM_LIBRARY TARGET ${BoostSystemLibs} PROPERTY LOCATION) # dependency of boost.log
+set(LIBS ${BOOST_LOG_LIBRARY} ${BOOST_CHRONO_LIBRARY} ${BOOST_DATE_TIME_LIBRARY} ${BOOST_FILESYSTEM_LIBRARY} ${BOOST_THREAD_LIBRARY} ${BOOST_SYSTEM_LIBRARY})
+target_link_libraries(${FASTLIB_EXAMPLE_COMMUNICATION} ${LIBS})
+
+# Add test
+add_test(communication_tests ${FASTLIB_EXAMPLE_COMMUNICATION})

--- a/examples/communication/main.cpp
+++ b/examples/communication/main.cpp
@@ -25,7 +25,13 @@ int main(int argc, char *argv[])
 		int port = 1883;
 		int keepalive = 60;
 
+		BOOST_LOG_TRIVIAL(info) << "Creating a MQTT_communicator for use in test cases.";
 		fast::MQTT_communicator comm(id, subscribe_topic, publish_topic, host, port, keepalive, std::chrono::seconds(5));
+
+		BOOST_LOG_TRIVIAL(info) << "Test of a second MQTT_communicator instance with random id.";
+		{
+			fast::MQTT_communicator comm("", subscribe_topic, publish_topic, host, port, keepalive, std::chrono::seconds(5));
+		}
 		
 		BOOST_LOG_TRIVIAL(info) << "Send and receive test.";
 		{


### PR DESCRIPTION
- Logging can be disabled by using the "-DENABLE_LOGGING=OFF" option in cmake.
- Documentation improvements (closes #4)
- Added option to generate a random id
