### PR TITLE
Use QoS of 1 for sending messages to default publish topic

### DIFF
--- a/src/mqtt_communicator.cpp
+++ b/src/mqtt_communicator.cpp
@@ -277,7 +277,7 @@ void MQTT_communicator::on_message(const mosquitto_message *msg)
 
 void MQTT_communicator::send_message(const std::string &message)
 {
-	send_message(message, "", 2);
+	send_message(message, "", 1);
 }
 
 void MQTT_communicator::send_message(const std::string &message, const std::string &topic, int qos)


### PR DESCRIPTION
Seems to be more reliable than QoS 2 if the message is directly 
sent before the destructor is called.
