### PR TITLE
Fixed migrate result serialization

### DIFF
--- a/include/fast-lib/serializable.hpp
+++ b/include/fast-lib/serializable.hpp
@@ -100,3 +100,12 @@ namespace YAML
 		};\
 	};
 #endif
+
+namespace fast {
+namespace yaml {
+
+// merges rhs into lhs
+void merge_node(YAML::Node &lhs, const YAML::Node &rhs);
+
+}
+}

--- a/src/message/migfra/result.cpp
+++ b/src/message/migfra/result.cpp
@@ -8,9 +8,6 @@
 
 #include <fast-lib/message/migfra/result.hpp>
 
-// Alias merge_node function
-const auto &merge_node = fast::yaml::merge_node;
-
 namespace fast {
 namespace msg {
 namespace migfra {
@@ -32,7 +29,7 @@ YAML::Node Result_container::emit() const
 	YAML::Node node;
 	node["result"] = title;
 	if (title == "vm migrated")
-		merge_node(node, results.at(0).emit());
+		fast::yaml::merge_node(node, results.at(0).emit());
 	else
 		node["list"] = results;
 	if (id != "")

--- a/src/message/migfra/result.cpp
+++ b/src/message/migfra/result.cpp
@@ -8,6 +8,9 @@
 
 #include <fast-lib/message/migfra/result.hpp>
 
+// Alias merge_node function
+const auto &merge_node = fast::yaml::merge_node;
+
 namespace fast {
 namespace msg {
 namespace migfra {
@@ -28,7 +31,10 @@ YAML::Node Result_container::emit() const
 {
 	YAML::Node node;
 	node["result"] = title;
-	node["list"] = results;
+	if (title == "vm migrated")
+		merge_node(node, results.at(0).emit());
+	else
+		node["list"] = results;
 	if (id != "")
 		node["id"] = id;
 	return node;

--- a/src/message/migfra/result.cpp
+++ b/src/message/migfra/result.cpp
@@ -40,7 +40,12 @@ YAML::Node Result_container::emit() const
 void Result_container::load(const YAML::Node &node)
 {
 	fast::load(title, node["result"]);
-	fast::load(results, node["list"]);
+	if (title == "vm migrated") {
+		results.emplace_back();
+		fast::load(results[0], node);
+	} else {
+		fast::load(results, node["list"]);
+	}
 	fast::load(id, node["id"], "");
 }
 

--- a/src/message/migfra/task.cpp
+++ b/src/message/migfra/task.cpp
@@ -94,8 +94,9 @@ std::string Task_container::type(bool enable_result_format) const
 YAML::Node Task_container::emit() const
 {
 	YAML::Node node;
-	node["task"] = type();
-	if (type() == "migrate vm") {
+	auto type_str = type();
+	node["task"] = type_str;
+	if (type_str == "migrate vm") {
 		merge_node(node, tasks.front()->emit());
 	} else {
 		node["vm-configurations"] = tasks;

--- a/src/message/migfra/task.cpp
+++ b/src/message/migfra/task.cpp
@@ -10,20 +10,12 @@
 
 #include <iostream>
 
+// Alias merge_node function
+const auto &merge_node = fast::yaml::merge_node;
+
 namespace fast {
 namespace msg {
 namespace migfra {
-
-// merges rhs into lhs
-void merge_node(YAML::Node &lhs, const YAML::Node &rhs)
-{
-	for (const auto &node : rhs) {
-		std::string tag = YAML::Dump(node.first);
-		if (!lhs[tag]) {
-			lhs[tag] = rhs[tag];
-		}
-	}
-}
 
 Task::Task() :
 	concurrent_execution("concurrent-execution"),

--- a/src/serializable.cpp
+++ b/src/serializable.cpp
@@ -18,4 +18,19 @@ namespace fast
 	{
 		load(YAML::Load(str));
 	}
+
+	namespace yaml {
+	
+		void merge_node(YAML::Node &lhs, const YAML::Node &rhs)
+		{
+			for (const auto &node : rhs) {
+				std::string tag = YAML::Dump(node.first);
+				if (!lhs[tag]) {
+					lhs[tag] = rhs[tag];
+				}
+			}
+		}
+	
+	}
+
 }


### PR DESCRIPTION
This omits the "list" tag for the migrate result.
Fixes fast-project/migration-framework#35.
