### PR TITLE
add suspend/resume tasks for migration-framework

### DIFF
--- a/include/fast-lib/message/migfra/task.hpp
+++ b/include/fast-lib/message/migfra/task.hpp
@@ -210,6 +210,48 @@ struct Repin :
 };
 
 /**
+ * \brief Task to suspend the execution of a single virtual machine.
+ */
+struct Suspend :
+	public Task
+{
+	Suspend();
+	/**
+	 * \brief Constructor for Suspend task.
+	 *
+	 * \param vm_name The name of the virtual machine to stop.
+	 * \param concurrent_execution Execute this Task in dedicated thread.
+	 */
+	Suspend(std::string vm_name, bool concurrent_execution);
+
+	YAML::Node emit() const override;
+	void load(const YAML::Node &node) override;
+
+	std::string vm_name;
+};
+
+/**
+ * \brief Task to resume the execution of a single virtual machine.
+ */
+struct Resume :
+	public Task
+{
+	Resume();
+	/**
+	 * \brief Constructor for Suspend task.
+	 *
+	 * \param vm_name The name of the virtual machine to stop.
+	 * \param concurrent_execution Execute this Task in dedicated thread.
+	 */
+	Resume(std::string vm_name, bool concurrent_execution);
+
+	YAML::Node emit() const override;
+	void load(const YAML::Node &node) override;
+
+	std::string vm_name;
+};
+
+/**
  * \brief Task to quit migfra.
  */
 struct Quit :
@@ -230,6 +272,8 @@ YAML_CONVERT_IMPL(fast::msg::migfra::Start)
 YAML_CONVERT_IMPL(fast::msg::migfra::Stop)
 YAML_CONVERT_IMPL(fast::msg::migfra::Migrate)
 YAML_CONVERT_IMPL(fast::msg::migfra::Repin)
+YAML_CONVERT_IMPL(fast::msg::migfra::Suspend)
+YAML_CONVERT_IMPL(fast::msg::migfra::Resume)
 YAML_CONVERT_IMPL(fast::msg::migfra::Quit)
 
 #endif

--- a/test/task_test.cpp
+++ b/test/task_test.cpp
@@ -151,6 +151,32 @@ struct Task_tester :
 		fructose_assert(r2.vcpu_map == r1.vcpu_map);
 	}
 
+	void suspend(const std::string &test_name)
+	{
+		(void) test_name;
+		Suspend suspend1;
+		suspend1.vm_name = "vm1";
+
+		Suspend suspend2;
+		auto buf = suspend1.to_string();
+		std::cout << "Serialized string: " << buf << std::endl;
+		suspend2.from_string(buf);
+		fructose_assert_eq(suspend2.vm_name, suspend1.vm_name);
+	}
+
+	void resume(const std::string &test_name)
+	{
+		(void) test_name;
+		Resume resume1;
+		resume1.vm_name = "vm1";
+
+		Resume resume2;
+		auto buf = resume1.to_string();
+		std::cout << "Serialized string: " << buf << std::endl;
+		resume2.from_string(buf);
+		fructose_assert_eq(resume2.vm_name, resume1.vm_name);
+	}
+
 	void quit(const std::string &test_name)
 	{
 		(void) test_name;
@@ -226,6 +252,8 @@ int main(int argc, char **argv)
 	tests.add_test("stop2", &Task_tester::stop2);
 	tests.add_test("migrate", &Task_tester::migrate);
 	tests.add_test("repin", &Task_tester::repin);
+	tests.add_test("suspend", &Task_tester::suspend);
+	tests.add_test("resume", &Task_tester::resume);
 	tests.add_test("quit", &Task_tester::quit);
 	tests.add_test("task_cont_start", &Task_tester::task_cont_start);
 	tests.add_test("task_cont_migrate", &Task_tester::task_cont_migrate);


### PR DESCRIPTION
-- Suspend: freeze VM without further access to CPU and I/O ressources
-- Resume: restart VM from where it is frozen
-- see also: virDomain<Suspend/Resume>()