### PR TITLE
fix emitter of the task container for stop tasks

### DIFF
--- a/src/message/migfra/task.cpp
+++ b/src/message/migfra/task.cpp
@@ -98,6 +98,8 @@ YAML::Node Task_container::emit() const
 		merge_node(node, tasks.front()->emit());
 	} else if (type_str == "repin vm") {
 		merge_node(node, tasks.front()->emit());
+	} else if (type_str == "stop vm") {
+		node["list"] = tasks;
 	} else {
 		node["vm-configurations"] = tasks;
 	}

--- a/src/message/migfra/task.cpp
+++ b/src/message/migfra/task.cpp
@@ -98,10 +98,10 @@ YAML::Node Task_container::emit() const
 		merge_node(node, tasks.front()->emit());
 	} else if (type_str == "repin vm") {
 		merge_node(node, tasks.front()->emit());
-	} else if (type_str == "stop vm") {
-		node["list"] = tasks;
-	} else {
+	} else if (type_str == "start vm") {
 		node["vm-configurations"] = tasks;
+	} else {
+		node["list"] = tasks;
 	}
 	merge_node(node, concurrent_execution.emit());
 	merge_node(node, id.emit());


### PR DESCRIPTION
The list of domains should be called 'list' instead of
'vm-configurations'.