### PR TITLE
memnode-map and vcpu-map support

### DIFF
--- a/include/fast-lib/message/migfra/task.hpp
+++ b/include/fast-lib/message/migfra/task.hpp
@@ -123,6 +123,7 @@ struct Start :
 	Optional<std::string> xml;
 	Optional<Device_ivshmem> ivshmem;
 	Optional<bool> transient;
+	Optional<std::vector<std::vector<unsigned int>>> vcpu_map;
 };
 
 /**

--- a/include/fast-lib/message/migfra/task.hpp
+++ b/include/fast-lib/message/migfra/task.hpp
@@ -118,6 +118,7 @@ struct Start :
 	Optional<std::string> vm_name;
 	Optional<unsigned int> vcpus;
 	Optional<unsigned long> memory;
+	Optional<std::vector<std::vector<unsigned int>>> memnode_map;
 	std::vector<PCI_id> pci_ids;
 	Optional<std::string> xml;
 	Optional<Device_ivshmem> ivshmem;

--- a/src/message/migfra/task.cpp
+++ b/src/message/migfra/task.cpp
@@ -248,6 +248,8 @@ YAML::Node Start::emit() const
 	merge_node(node, vcpus.emit());
 	merge_node(node, memory.emit());
 	merge_node(node, memnode_map.emit());
+	if (memnode_map.is_valid())
+		node[memnode_map.get_tag()].SetStyle(YAML::EmitterStyle::Flow);
 	merge_node(node, xml.emit());
 	merge_node(node, ivshmem.emit());
 	merge_node(node, transient.emit());

--- a/src/message/migfra/task.cpp
+++ b/src/message/migfra/task.cpp
@@ -211,7 +211,8 @@ Start::Start() :
 	memnode_map("memnode-map"),
 	xml("xml"),
 	ivshmem("ivshmem"),
-	transient("transient")
+	transient("transient"),
+	vcpu_map("vcpu-map")
 {
 }
 
@@ -224,7 +225,8 @@ Start::Start(std::string vm_name, unsigned int vcpus, unsigned long memory, std:
 	pci_ids(std::move(pci_ids)),
 	xml("xml"),
 	ivshmem("ivshmem"),
-	transient("transient")
+	transient("transient"),
+	vcpu_map("vcpu-map")
 {
 }
 
@@ -237,7 +239,8 @@ Start::Start(std::string xml, std::vector<PCI_id> pci_ids, bool concurrent_execu
 	pci_ids(std::move(pci_ids)),
 	xml("xml", xml),
 	ivshmem("ivshmem"),
-	transient("transient")
+	transient("transient"),
+	vcpu_map("vcpu-map")
 {
 }
 
@@ -255,6 +258,9 @@ YAML::Node Start::emit() const
 	merge_node(node, transient.emit());
 	if (!pci_ids.empty())
 		node["pci-ids"] = pci_ids;
+	merge_node(node, vcpu_map.emit());
+	if (vcpu_map.is_valid())
+		node[vcpu_map.get_tag()].SetStyle(YAML::EmitterStyle::Flow);
 	return node;
 }
 
@@ -269,6 +275,7 @@ void Start::load(const YAML::Node &node)
 	xml.load(node);
 	ivshmem.load(node);
 	transient.load(node);
+	vcpu_map.load(node);
 }
 
 //

--- a/src/message/migfra/task.cpp
+++ b/src/message/migfra/task.cpp
@@ -208,6 +208,7 @@ Start::Start() :
 	vm_name("vm-name"),
 	vcpus("vcpus"),
 	memory("memory"),
+	memnode_map("memnode-map"),
 	xml("xml"),
 	ivshmem("ivshmem"),
 	transient("transient")
@@ -219,6 +220,7 @@ Start::Start(std::string vm_name, unsigned int vcpus, unsigned long memory, std:
 	vm_name("vm-name", std::move(vm_name)),
 	vcpus("vcpus", vcpus),
 	memory("memory", memory),
+	memnode_map("memnode-map"),
 	pci_ids(std::move(pci_ids)),
 	xml("xml"),
 	ivshmem("ivshmem"),
@@ -231,6 +233,7 @@ Start::Start(std::string xml, std::vector<PCI_id> pci_ids, bool concurrent_execu
 	vm_name("vm-name"),
 	vcpus("vcpus"),
 	memory("memory"),
+	memnode_map("memnode-map"),
 	pci_ids(std::move(pci_ids)),
 	xml("xml", xml),
 	ivshmem("ivshmem"),
@@ -244,6 +247,7 @@ YAML::Node Start::emit() const
 	merge_node(node, vm_name.emit());
 	merge_node(node, vcpus.emit());
 	merge_node(node, memory.emit());
+	merge_node(node, memnode_map.emit());
 	merge_node(node, xml.emit());
 	merge_node(node, ivshmem.emit());
 	merge_node(node, transient.emit());
@@ -258,6 +262,7 @@ void Start::load(const YAML::Node &node)
 	vm_name.load(node);
 	vcpus.load(node);
 	memory.load(node);
+	memnode_map.load(node);
 	fast::load(pci_ids, node["pci-ids"], std::vector<PCI_id>());
 	xml.load(node);
 	ivshmem.load(node);


### PR DESCRIPTION
This PR adds a memnode-map field to the start task. Furthermore, the vcpu-map field that is used in the repin and migrate tasks has been made available to the start task as well.